### PR TITLE
Create Makefile and dockerimages for automated build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .terraform
 **/terraform.tfstate*
 **/.terraform.tfstate*
+bin

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .terraform
 **/terraform.tfstate*
 **/.terraform.tfstate*
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+
+all: build
+
+# Define constants
+##################
+BINDIR        ?= bin
+CLUSTERAPI_BIN = $(BINDIR)/cluster-api
+VERSION       ?= $(shell git describe --always --abbrev=7 --dirty)
+GO_VERSION     = 1.9
+
+CLUSTER_API_IMAGE = $(REGISTRY)cluster-api:$(VERSION)
+CONTROLLER_MANAGER_IMAGE = $(REGISTRY)controller-manager:$(VERSION)
+
+# Some prereq stuff
+###################
+
+.apiServerBuilderImage: build/apiserver-builder/Dockerfile
+	sed "s/GO_VERSION/$(GO_VERSION)/g" < build/apiserver-builder/Dockerfile | \
+	  docker build -t apiserverbuilderimage -
+
+clean: .clean-bin .clean-build-image
+
+clean-bin:
+	rm -rf $(BINDIR)
+
+clean-build-image:
+	docker rmi -f apiserverbuilderimage > /dev/null 2>&1 || true
+
+# Build
+#######
+
+build: kubernetes-cluster-api kubernetes-controller-manager
+
+.PHONY: $(CLUSTERAPI_BIN)/apiserver
+$(CLUSTERAPI_BIN)/apiserver: .apiServerBuilderImage
+	mkdir -p $(PWD)/$(CLUSTERAPI_BIN) && docker run --security-opt label:disable -v $(PWD)/$(CLUSTERAPI_BIN):/output --entrypoint=/bin/bash apiserverbuilderimage -c "export GOPATH=/go && mkdir -p /go/src/sigs.k8s.io/cluster-api && cd /go/src/sigs.k8s.io/cluster-api && git clone https://github.com/kubernetes-sigs/cluster-api.git . && apiserver-boot build executables --generate=false && touch /output/controller-manager /output/apiserver && cp bin/* /output"
+
+.PHONY: kubernetes-cluster-api
+kubernetes-cluster-api: $(CLUSTERAPI_BIN)/apiserver build/clusterapi-image/Dockerfile
+	cp build/clusterapi-image/Dockerfile $(CLUSTERAPI_BIN)
+	docker build -t $(CLUSTER_API_IMAGE) ./$(CLUSTERAPI_BIN)
+
+kubernetes-controller-manager: $(CLUSTERAPI_BIN)/controller-manager build/controller-manager-image/Dockerfile
+	cp build/controller-manager-image/Dockerfile $(CLUSTERAPI_BIN)
+	docker build -t $(CONTROLLER_MANAGER_IMAGE) ./$(CLUSTERAPI_BIN)
+
+push: kubernetes-cluster-api kubernetes-controller-manager
+	docker push $(CLUSTER_API_IMAGE)
+	docker push $(CONTROLLER_MANAGER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+BINDIR?= bin
+PLATFORM?=linux
+ARCH?=amd64
+
+GO_BUILD= env GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -i $(GOFLAGS) \
+
+.PHONY: $(BINDIR)/aws-machine-controller
+aws-machine-controller: $(BINDIR)/aws-machine-controller
+$(BINDIR)/aws-machine-controller:
+	$(GO_BUILD) -o $@ ./cmd
+
+aws-machine-controller-image: $(BINDIR)/aws-machine-controller
+	docker build -t aws-machine-controller --file build/aws-machine-controller/Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: build
+all: build images
 
 # Define constants
 ##################
@@ -7,8 +7,14 @@ PLATFORM      ?= linux
 ARCH          ?= amd64
 CLUSTERAPI_BIN = $(BINDIR)/cluster-api
 VERSION       ?= $(shell git describe --always --abbrev=7 --dirty)
-GO_VERSION     = 1.9
+GO_VERSION     = 1.10
 GO_BUILD       = env GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -i $(GOFLAGS)
+
+AWS_MACHINE_CONTROLLER_PKG = github.com/enxebre/cluster-api-provider-aws
+
+DOCKER_CMD     = docker run --security-opt label:disable --rm -v $(PWD):/go/src/$(AWS_MACHINE_CONTROLLER_PKG) \
+                 -v $(PWD)/.pkg:/go/pkg buildimage
+
 
 CLUSTER_API_IMAGE = $(REGISTRY)cluster-api:$(VERSION)
 CONTROLLER_MANAGER_IMAGE = $(REGISTRY)controller-manager:$(VERSION)
@@ -17,45 +23,61 @@ AWS_MACHINE_CONTROLLER_IMAGE = $(REGISTRY)aws-machine-controller:$(VERSION)
 # Some prereq stuff
 ###################
 
+.clusterOperatorBuildImage: build/build-image/Dockerfile
+	sed "s/GO_VERSION/$(GO_VERSION)/g" < build/build-image/Dockerfile | \
+	  docker build -t buildimage -
+
 .apiServerBuilderImage: build/apiserver-builder/Dockerfile
 	sed "s/GO_VERSION/$(GO_VERSION)/g" < build/apiserver-builder/Dockerfile | \
 	  docker build -t apiserverbuilderimage -
 
-clean: .clean-bin .clean-build-image
+clean: clean-bin clean-images ## Clean everything
 
-clean-bin:
-	rm -rf $(BINDIR)
+clean-bin: ## Remove build directory
+	$(DOCKER_CMD) rm -rf $(BINDIR)
 
-clean-build-image:
+clean-images: ## Remove built images
+	$(DOCKER_CMD) rm -rf .pkg
 	docker rmi -f apiserverbuilderimage > /dev/null 2>&1 || true
+	docker rmi -f buildimage > /dev/null 2>&1 || true
 
 # Build
 #######
 
-build: kubernetes-cluster-api kubernetes-controller-manager aws-machine-controller
+build: .clusterOperatorBuildImage apiserver aws-machine-controller ## Build all binaries
+images: aws-machine-controller-image k8s-cluster-api-image k8s-controller-manager-image ## Create all images
 
 .PHONY: $(BINDIR)/aws-machine-controller
-aws-machine-controller: $(BINDIR)/aws-machine-controller
-$(BINDIR)/aws-machine-controller:
-	$(GO_BUILD) -o $@ ./cmd
+aws-machine-controller: $(BINDIR)/aws-machine-controller ## Build aws-machine-controller binary
+$(BINDIR)/aws-machine-controller: .clusterOperatorBuildImage
+	mkdir -p $(PWD)/$(BINDIR)
+	$(DOCKER_CMD) $(GO_BUILD) -o $@ $(AWS_MACHINE_CONTROLLER_PKG)/cmd
 
-aws-machine-controller-image: $(BINDIR)/aws-machine-controller
-	docker build -t $(AWS_MACHINE_CONTROLLER_IMAGE) --file build/aws-machine-controller/Dockerfile .
+.PHONY: aws-machine-controller-image
+aws-machine-controller-image: $(BINDIR)/aws-machine-controller aws-machine-controller ## Create aws-machine-controller image
+	cp build/aws-machine-controller/Dockerfile $(BINDIR)/Dockerfile
+	docker build -t $(AWS_MACHINE_CONTROLLER_IMAGE) ./$(BINDIR)
 
 .PHONY: $(CLUSTERAPI_BIN)/apiserver
+apiserver: $(CLUSTERAPI_BIN)/apiserver ## Build cluster-api and controller-manager binaries
 $(CLUSTERAPI_BIN)/apiserver: .apiServerBuilderImage
 	mkdir -p $(PWD)/$(CLUSTERAPI_BIN) && docker run --security-opt label:disable -v $(PWD)/$(CLUSTERAPI_BIN):/output --entrypoint=/bin/bash apiserverbuilderimage -c "export GOPATH=/go && mkdir -p /go/src/sigs.k8s.io/cluster-api && cd /go/src/sigs.k8s.io/cluster-api && git clone https://github.com/kubernetes-sigs/cluster-api.git . && apiserver-boot build executables --generate=false && touch /output/controller-manager /output/apiserver && cp bin/* /output"
 
-.PHONY: kubernetes-cluster-api
-kubernetes-cluster-api: $(CLUSTERAPI_BIN)/apiserver build/clusterapi-image/Dockerfile
+.PHONY: k8s-cluster-api-image
+k8s-cluster-api-image: $(CLUSTERAPI_BIN)/apiserver build/clusterapi-image/Dockerfile ## Build cluster-api image
 	cp build/clusterapi-image/Dockerfile $(CLUSTERAPI_BIN)
 	docker build -t $(CLUSTER_API_IMAGE) ./$(CLUSTERAPI_BIN)
 
-kubernetes-controller-manager: $(CLUSTERAPI_BIN)/controller-manager build/controller-manager-image/Dockerfile
+.PHONY: k8s-controller-manager-image
+k8s-controller-manager-image: $(CLUSTERAPI_BIN)/controller-manager build/controller-manager-image/Dockerfile ## Build controller-manager image
 	cp build/controller-manager-image/Dockerfile $(CLUSTERAPI_BIN)
 	docker build -t $(CONTROLLER_MANAGER_IMAGE) ./$(CLUSTERAPI_BIN)
 
-push: kubernetes-cluster-api kubernetes-controller-manager aws-machine-controller-image
+push: k8s-cluster-api-image kubernetes-controller-manager-image aws-machine-controller-image ## Push all images to registry
 	docker push $(CLUSTER_API_IMAGE)
 	docker push $(CONTROLLER_MANAGER_IMAGE)
 	docker push $(AWS_MACHINE_CONTROLLER_IMAGE)
+
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,4 @@ kubernetes-controller-manager: $(CLUSTERAPI_BIN)/controller-manager build/contro
 push: kubernetes-cluster-api kubernetes-controller-manager aws-machine-controller-image
 	docker push $(CLUSTER_API_IMAGE)
 	docker push $(CONTROLLER_MANAGER_IMAGE)
+	docker push $(AWS_MACHINE_CONTROLLER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ AWS_MACHINE_CONTROLLER_IMAGE = $(REGISTRY)aws-machine-controller:$(VERSION)
 # Some prereq stuff
 ###################
 
-.clusterOperatorBuildImage: build/build-image/Dockerfile
+.buildImage: build/build-image/Dockerfile
 	sed "s/GO_VERSION/$(GO_VERSION)/g" < build/build-image/Dockerfile | \
 	  docker build -t buildimage -
 
@@ -44,12 +44,12 @@ clean-images: ## Remove built images
 # Build
 #######
 
-build: .clusterOperatorBuildImage apiserver aws-machine-controller ## Build all binaries
+build: .buildImage apiserver aws-machine-controller ## Build all binaries
 images: aws-machine-controller-image k8s-cluster-api-image k8s-controller-manager-image ## Create all images
 
 .PHONY: $(BINDIR)/aws-machine-controller
 aws-machine-controller: $(BINDIR)/aws-machine-controller ## Build aws-machine-controller binary
-$(BINDIR)/aws-machine-controller: .clusterOperatorBuildImage
+$(BINDIR)/aws-machine-controller: .buildImage
 	mkdir -p $(PWD)/$(BINDIR)
 	$(DOCKER_CMD) $(GO_BUILD) -o $@ $(AWS_MACHINE_CONTROLLER_PKG)/cmd
 

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ build: kubernetes-cluster-api kubernetes-controller-manager aws-machine-controll
 .PHONY: $(BINDIR)/aws-machine-controller
 aws-machine-controller: $(BINDIR)/aws-machine-controller
 $(BINDIR)/aws-machine-controller:
-  $(GO_BUILD) -o $@ ./cmd
+	$(GO_BUILD) -o $@ ./cmd
 
 aws-machine-controller-image: $(BINDIR)/aws-machine-controller
-  docker build -t $(AWS_MACHINE_CONTROLLER_IMAGE) --file build/aws-machine-controller/Dockerfile .
+	docker build -t $(AWS_MACHINE_CONTROLLER_IMAGE) --file build/aws-machine-controller/Dockerfile .
 
 .PHONY: $(CLUSTERAPI_BIN)/apiserver
 $(CLUSTERAPI_BIN)/apiserver: .apiServerBuilderImage

--- a/build/apiserver-builder/Dockerfile
+++ b/build/apiserver-builder/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:GO_VERSION
+
+# Avoid permission issues when glide pulls mercurial repos as root
+RUN printf "[trusted]\nusers = *\n" > /root/.hgrc
+
+RUN cd /tmp && \
+    curl -L -O https://github.com/kubernetes-incubator/apiserver-builder/releases/download/v1.9-alpha.2/apiserver-builder-v1.9-alpha.2-linux-amd64.tar.gz && \
+    tar -xzf apiserver-builder-v1.9-alpha.2-linux-amd64.tar.gz && \
+    cp ./bin/* /usr/bin

--- a/build/aws-machine-controller/Dockerfile
+++ b/build/aws-machine-controller/Dockerfile
@@ -19,6 +19,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get install ca-certificates -y && \
     rm -rf /var/lib/apt/lists/*
 
-COPY bin/aws-machine-controller opt/services/
+COPY aws-machine-controller opt/services/
 
 ENTRYPOINT ["/opt/services/aws-machine-controller"]

--- a/build/aws-machine-controller/Dockerfile
+++ b/build/aws-machine-controller/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/google-containers/debian-base-amd64:0.2
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install ca-certificates -y && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY bin/aws-machine-controller opt/services/
+
+ENTRYPOINT ["/opt/services/aws-machine-controller"]

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -1,0 +1,35 @@
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:GO_VERSION
+
+# Avoid permission issues when glide pulls mercurial repos as root
+RUN printf "[trusted]\nusers = *\n" > /root/.hgrc
+
+# Install glide as root
+ENV GLIDE_VERSION=v0.12.3 \
+    GLIDE_HOME=/go/src/github.com/openshift/cluster-operator/.glide
+RUN curl -sSL https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz \
+    | tar -vxz -C /usr/local/bin --strip=1
+
+# Install the golint, use this to check our source for niceness
+RUN go get -u github.com/golang/lint/golint
+
+# Create the full dir tree that we'll mount our src into when we run the image
+#RUN mkdir -p /go/src/github.com/openshift/cluster-operator
+RUN mkdir -p /go/src/github.com/enxebre/cluster-api-provider-aws
+
+# Default to our src dir
+WORKDIR /go/src/github.com/enxebre/cluster-api-provider-aws

--- a/build/clusterapi-image/Dockerfile
+++ b/build/clusterapi-image/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:14.04
+
+RUN apt-get update
+RUN apt-get install -y ca-certificates
+
+ADD apiserver .
+
+RUN chmod +x apiserver
+
+ENTRYPOINT ["./apiserver"]

--- a/build/controller-manager-image/Dockerfile
+++ b/build/controller-manager-image/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:14.04
+
+RUN apt-get update
+RUN apt-get install -y ca-certificates
+
+ADD controller-manager .
+
+RUN chmod +x controller-manager
+
+ENTRYPOINT ["./controller-manager"]


### PR DESCRIPTION
Docker images which could be created with `make` command:
- controller-manager
- cluster-api
- aws-machine-controller

Everything is build in docker container, so there is a little dependencies needed on the host machine.

There is also `make help` command to see what are available subcommands and what they do.

Closes #2 
Closes #1 